### PR TITLE
Crud-bench: add SurrealKV

### DIFF
--- a/.github/workflows/crud-bench.yml
+++ b/.github/workflows/crud-bench.yml
@@ -55,3 +55,6 @@ jobs:
       - name: Bench SurrealDB/RocksDB
         run: cargo run -- -d surrealdb-rocksdb -s 10000 -t 3
 
+      - name: Bench SurrealDB/KV
+        run: cargo run -- -d surrealdb-kv -s 10000 -t 3
+

--- a/crud-bench/README.md
+++ b/crud-bench/README.md
@@ -82,6 +82,14 @@ Run the benchmark against SurreadDB with RocksDB:
 cargo run -r -- -d surrealdb-rocksdb -s 100000 -t 3
 ```
 
+## SurrealDB/SurrealKV benchmark
+
+Run the benchmark against SurreadDB with SurrealKV:
+
+```bash
+cargo run -r -- -d surrealdb-kv -s 100000 -t 3
+```
+
 ## SurrealDB local benchmark
 
 Run the benchmark against an already running SurrealDB instance:

--- a/crud-bench/src/main.rs
+++ b/crud-bench/src/main.rs
@@ -7,8 +7,8 @@ use crate::docker::DockerContainer;
 use crate::mongodb::{MongoDBClientProvider, MONGODB_DOCKER_PARAMS};
 use crate::postgres::{PostgresClientProvider, POSTGRES_DOCKER_PARAMS};
 use crate::surrealdb::{
-	SurrealDBClientProvider, SURREAL_MEMORY_DOCKER_PARAMS, SURREAL_ROCKSDB_DOCKER_PARAMS,
-	SURREAL_SPEEDB_DOCKER_PARAMS,
+	SurrealDBClientProvider, SURREAL_KV_DOCKER_PARAMS, SURREAL_MEMORY_DOCKER_PARAMS,
+	SURREAL_ROCKSDB_DOCKER_PARAMS, SURREAL_SPEEDB_DOCKER_PARAMS,
 };
 
 mod benchmark;
@@ -44,6 +44,7 @@ pub(crate) enum Database {
 	SurrealdbMemory,
 	SurrealdbRocksdb,
 	SurrealdbSpeedb,
+	SurrealdbKv,
 	Mongodb,
 	Postgresql,
 }
@@ -56,6 +57,7 @@ impl Database {
 			Database::SurrealdbMemory => SURREAL_MEMORY_DOCKER_PARAMS,
 			Database::SurrealdbRocksdb => SURREAL_ROCKSDB_DOCKER_PARAMS,
 			Database::SurrealdbSpeedb => SURREAL_SPEEDB_DOCKER_PARAMS,
+			Database::SurrealdbKv => SURREAL_KV_DOCKER_PARAMS,
 			Database::Mongodb => MONGODB_DOCKER_PARAMS,
 			Database::Postgresql => POSTGRES_DOCKER_PARAMS,
 		};
@@ -70,7 +72,8 @@ impl Database {
 			Database::Surrealdb
 			| Database::SurrealdbMemory
 			| Database::SurrealdbRocksdb
-			| Database::SurrealdbSpeedb => benchmark.run(SurrealDBClientProvider::default()),
+			| Database::SurrealdbSpeedb
+			| Database::SurrealdbKv => benchmark.run(SurrealDBClientProvider::default()),
 			Database::Mongodb => benchmark.run(MongoDBClientProvider::default()),
 			Database::Postgresql => benchmark.run(PostgresClientProvider::default()),
 		}

--- a/crud-bench/src/surrealdb.rs
+++ b/crud-bench/src/surrealdb.rs
@@ -9,19 +9,25 @@ use crate::benchmark::{BenchmarkClient, BenchmarkClientProvider, Record};
 use crate::docker::DockerParams;
 
 pub(crate) const SURREAL_SPEEDB_DOCKER_PARAMS: DockerParams = DockerParams {
-	image: "surrealdb/surrealdb:v1.2.1",
+	image: "surrealdb/surrealdb:nightly",
 	pre_args: "-p 127.0.0.1:8000:8000",
 	post_args: "start --auth --user root --pass root speedb://tmp/crud-bench.db",
 };
 
 pub(crate) const SURREAL_ROCKSDB_DOCKER_PARAMS: DockerParams = DockerParams {
-	image: "surrealdb/surrealdb:v1.2.1",
+	image: "surrealdb/surrealdb:nightly",
 	pre_args: "-p 127.0.0.1:8000:8000",
 	post_args: "start --auth --user root --pass root rocksdb://tmp/crud-bench.db",
 };
 
+pub(crate) const SURREAL_KV_DOCKER_PARAMS: DockerParams = DockerParams {
+	image: "surrealdb/surrealdb:nightly",
+	pre_args: "-p 127.0.0.1:8000:8000",
+	post_args: "start --auth --user root --pass root surrealkv://tmp/crud-bench.db",
+};
+
 pub(crate) const SURREAL_MEMORY_DOCKER_PARAMS: DockerParams = DockerParams {
-	image: "surrealdb/surrealdb:v1.2.1",
+	image: "surrealdb/surrealdb:nightly",
 	pre_args: "-p 127.0.0.1:8000:8000",
 	post_args: "start --auth --user root --pass root memory",
 };


### PR DESCRIPTION
Add support for SurrealDB/SurrealKV

```bash
 cargo run -r -- -d surrealdb-kv -s 100000 -t 3
```

```
Benchmark result for SurrealdbKv on docker Some("surrealdb/surrealdb:nightly") - Samples: 100000 - Threads: 3
[C]reates: 13.910333917s
[R]eads: 13.800410583s
[U]pdates: 14.482852s
[D]eletes: 65.6455805s
```